### PR TITLE
fix: remove leading zeros from all jwk exported fields

### DIFF
--- a/android/src/main/java/com/pedrouid/crypto/RCTRsaUtils.java
+++ b/android/src/main/java/com/pedrouid/crypto/RCTRsaUtils.java
@@ -152,13 +152,13 @@ public class RCTRsaUtils extends ReactContextBaseJavaModule {
 
     WritableMap jwk = Arguments.createMap();
     jwk.putString("n", toString(keyStruct.getModulus(), true));
-    jwk.putString("e", toString(keyStruct.getPublicExponent(), false));
-    jwk.putString("d", toString(keyStruct.getPrivateExponent(), false));
+    jwk.putString("e", toString(keyStruct.getPublicExponent(), true));
+    jwk.putString("d", toString(keyStruct.getPrivateExponent(), true));
     jwk.putString("p", toString(keyStruct.getPrime1(), true));
     jwk.putString("q", toString(keyStruct.getPrime2(), true));
     jwk.putString("dp", toString(keyStruct.getExponent1(), true));
     jwk.putString("dq", toString(keyStruct.getExponent2(), true));
-    jwk.putString("qi", toString(keyStruct.getCoefficient(), false));
+    jwk.putString("qi", toString(keyStruct.getCoefficient(), true));
 
     return jwk;
   }
@@ -178,7 +178,7 @@ public class RCTRsaUtils extends ReactContextBaseJavaModule {
 
   private String toString(BigInteger bigInteger, Boolean positive) {
     byte[] array = bigInteger.toByteArray();
-    if (positive) {
+    if (positive && array[0] == 0) {
       array = Arrays.copyOfRange(array, 1, array.length);
     }
     return Base64.encodeToString(array, Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP);


### PR DESCRIPTION
The key export code in `android\src\main\java\com\pedrouid\crypto\RCTRsaUtils.java` in function `exportKey` generates invalid JWK objects - it encodes the numbers with the leading 0 indicating a positive number. This is against the [RFC 7518](https://www.rfc-editor.org/rfc/rfc7518#:~:text=by%20this%20specification%3A-,Base64urlUInt,-The%20representation%20of) which explicitly states that all numbers are positive and should be represented in big endian with the minimum number of bytes - i.e. no leading zeros under any circumstances.

This causes an issue where if a user resets their E2E key on a mobile device, they cannot then use their E2E password in the browser, the browser code rejects the invalid JWK.
